### PR TITLE
Refresh dashboard navigation and quick access styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ Es soll den Büroalltag erleichtern und Prozesse digitalisieren.
 - 📅 **Reminders** – ToDo-System mit Fälligkeiten & Status
 - 📊 **Dashboard** – zentrale Übersicht über wichtige Daten
 
+## 🔍 Feature-Rundgang
+Damit du dir schneller einen Eindruck verschaffen kannst, wie sich die API im Alltag verhält, findest du hier einen kurzen Walkthrough der wichtigsten Endpunkte.
+
+### Mitarbeiterverwaltung
+- `GET /employees/` listet Mitarbeitende mit Such- und Paging-Parametern, z. B. `q`, `limit` oder `offset`, um gezielt Personalakten zu finden.【F:backend/app/routers/employees.py†L17-L31】
+- `POST /employees/` legt neue Mitarbeitende an und vergibt dabei automatisch eine UUID als Primärschlüssel sowie Zeitstempel für `created` und `updated`.【F:backend/app/routers/employees.py†L33-L48】
+- Für Korrekturen gibt es `PUT /employees/{id}` bzw. `DELETE /employees/{id}`; alternativ kannst du mit `PUT /employees/by_business/{employee_id}` auch über die externe Personalnummer aktualisieren, inklusive Konfliktprüfung auf doppelte E-Mails.【F:backend/app/routers/employees.py†L50-L97】
+
+### Dokumente & Krankmeldungen
+- `POST /documents/` hinterlegt Dateien wie Atteste oder Verträge zu einem Mitarbeitenden und speichert Status, Upload-Datum und optionale Notizen.【F:backend/app/routers/documents.py†L12-L37】
+- `GET /documents/` bietet Filter nach Mitarbeitenden, Status, Dokumenttyp und Freitextsuche in Titel/Notizen – ideal für Audits.【F:backend/app/routers/documents.py†L22-L37】
+- Krankmeldungen werden über `POST /sick-leaves/` inkl. Verknüpfung zu einem Dokument erfasst; die Liste ist über optionale Filter wie `employee_id` und Pagination zugänglich.【F:backend/app/routers/sick_leaves.py†L14-L35】
+
+### Urlaubsverwaltung & Zeiterfassung
+- Urlaubsanträge kommen über `POST /vacation-requests/` ins System; sie tragen Statuswerte wie `pending`, `approved` oder `rejected`, die per Update-Endpunkt angepasst werden können.【F:backend/app/models.py†L108-L151】
+- Die Zeiterfassung (`/time-entries/`) speichert Start-/Endzeiten inklusive Notizen und lässt sich für einzelne Mitarbeitende filtern, um Tages- oder Wochenübersichten zu erzeugen.【F:backend/app/routers/time_entries.py†L9-L37】
+
+### Reminder & ToDo-Management
+- `POST /reminders/` legt Aufgaben mit Fälligkeit an und berechnet serverseitig ein `is_overdue`-Flag, sobald eine offene Aufgabe überfällig ist.【F:backend/app/routers/reminders.py†L54-L96】
+- Für Fachbereiche ohne UUID-Kenntnis gibt es Business-Routen wie `GET /reminders/by_business/{employee_id}`, die automatisch nach der Personalnummer auflösen und sortiert zurückgeben.【F:backend/app/routers/reminders.py†L26-L52】
+- Statuswechsel (z. B. erledigt markieren) erfolgen bequem über `POST /reminders/{id}/done`.【F:backend/app/routers/reminders.py†L124-L143】
+
+### Daten befüllen & Demo
+- Mit `python backend/seed_workmate.py --employees 5` lässt sich eine lokale Instanz per REST-Calls mit Testdaten füllen. Das Skript erzeugt Mitarbeitende, Dokumente, Reminder, Krankmeldungen, Urlaube und Zeiteinträge in einem Rutsch.【F:backend/seed_workmate.py†L1-L132】
+
 ---
 
 ## 🛠️ Tech Stack

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,13 +1,39 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const navItems = [
+  { name: 'overview', label: 'Übersicht', to: { name: 'overview' } },
+]
+
+const currentRouteName = computed(() => route.name)
+</script>
 
 <template>
-  <div>
-    <header class="sticky top-0 z-10 backdrop-blur bg-brand-bg/90 border-b border-white/5 shadow-[0_0_20px_rgba(255,145,0,0.2)]">
-      <div class="container-page flex items-center gap-3 py-3">
-        <div class="h-7 w-7 rounded-lg bg-brand-accent"></div>
-        <h1>Workmate Dashboard</h1>
-        <nav class="ml-auto flex items-center gap-4 text-sm">
-          <RouterLink to="/" class="link">Overview</RouterLink>
+  <div class="min-h-screen bg-[radial-gradient(circle_at_top,#2f2c24_0%,#1d1c1d_55%,#141316_100%)]">
+    <header class="sticky top-0 z-20 border-b border-white/5 bg-brand-bg/85 backdrop-blur shadow-[0_10px_40px_rgba(0,0,0,0.35)]">
+      <div class="container-page flex flex-wrap items-center gap-x-4 gap-y-2 py-4">
+        <div class="flex items-center gap-2">
+          <div class="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-accent/90 text-sm font-bold text-black shadow-[0_6px_20px_rgba(255,145,0,0.35)]">
+            WM
+          </div>
+          <div>
+            <p class="text-xs uppercase tracking-[0.32em] text-brand-muted">Workmate</p>
+            <h1 class="leading-tight">HR Command Center</h1>
+          </div>
+        </div>
+        <nav class="ml-auto flex items-center gap-1 text-sm">
+          <RouterLink
+            v-for="item in navItems"
+            :key="item.name"
+            :to="item.to"
+            class="nav-link"
+            :class="{ 'nav-link--active': currentRouteName === item.name }"
+          >
+            {{ item.label }}
+          </RouterLink>
         </nav>
       </div>
     </header>

--- a/ui/src/components/Section.vue
+++ b/ui/src/components/Section.vue
@@ -1,17 +1,35 @@
 <script setup lang="ts">
-const props = defineProps<{
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
   title: string
   right?: string
-}>()
+  description?: string
+  columns?: 'auto' | 'single' | 'double'
+}>(), {
+  columns: 'auto',
+})
+
+const gridClass = computed(() => {
+  switch (props.columns) {
+    case 'single':
+      return 'grid-cols-1'
+    case 'double':
+      return 'md:grid-cols-2'
+    default:
+      return 'md:grid-cols-2 lg:grid-cols-3'
+  }
+})
 </script>
 
 <template>
   <section class="mt-8">
-    <div class="flex items-center mb-3">
+    <div class="mb-3 flex items-start gap-2">
       <h2 class="text-lg md:text-xl font-semibold tracking-tight">{{ title }}</h2>
       <div v-if="right" class="ml-auto text-sm text-brand-muted">{{ right }}</div>
     </div>
-    <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <p v-if="props.description" class="muted mb-4 max-w-2xl">{{ props.description }}</p>
+    <div :class="['grid gap-4', gridClass]">
       <slot />
     </div>
   </section>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -51,8 +51,12 @@ section { @apply mt-8; }
   .card-title { @apply text-base md:text-lg font-semibold tracking-tight; }
   .kpi        { @apply text-3xl md:text-4xl font-extrabold tracking-tight text-white; }
   .badge      { @apply inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium bg-white/10 text-white; }
-  .btn        { @apply inline-flex items-center justify-center rounded-xl px-6 py-2 bg-brand-accent text-black font-medium hover:opacity-90 transition; }
+  .btn        { @apply inline-flex items-center justify-center rounded-xl px-6 py-2 bg-brand-accent text-black font-medium shadow-[0_10px_25px_rgba(255,145,0,0.35)] hover:opacity-95 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60; }
+  .btn-secondary { @apply inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-5 py-2 text-sm font-medium text-white transition hover:border-brand-accent/40 hover:text-brand-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/40; }
   .link       { @apply text-brand-accent hover:underline; }
+  .input      { @apply w-40 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-brand-muted focus:border-brand-accent/60 focus:bg-black/20 focus:outline-none focus:ring-2 focus:ring-brand-accent/50 transition; }
+  .nav-link   { @apply inline-flex items-center gap-2 rounded-xl px-3 py-2 font-medium text-brand-muted hover:text-white hover:bg-white/5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/40; }
+  .nav-link--active { @apply bg-white/10 text-white shadow-[0_10px_25px_rgba(255,145,0,0.25)]; }
 }
 
 /* ----------------------------

--- a/ui/src/views/Overview.vue
+++ b/ui/src/views/Overview.vue
@@ -15,6 +15,7 @@ import AbsenceCalendar from '@/components/AbsenceCalendar.vue'
 const data = ref<DashboardOverview | null>(null)
 const err = ref<string | null>(null)
 const empSearch = ref('')
+const quickLinks = ['KIT-0001', 'KIT-0002', 'KIT-0003']
 
 // Router
 const route = useRoute()
@@ -27,6 +28,11 @@ const isEmployeeRoute = computed(() => route.name === 'employee')
 const hasDeptData = computed(() =>
   !!data.value && !!data.value.employees && Object.keys(data.value.employees.by_department || {}).length > 0
 )
+
+const departmentCount = computed(() => {
+  if (!data.value?.employees?.by_department) return 0
+  return Object.keys(data.value.employees.by_department).length
+})
 
 // Load
 onMounted(async () => {
@@ -41,7 +47,7 @@ onMounted(async () => {
 function openEmployee() {
   const id = empSearch.value.trim()
   if (!id) return
-  router.push({ name: 'employee', params: { id } })   // <- HIER: id statt employeeId
+  router.push({ name: 'employee', params: { employeeId: id } })
 }
 
 </script>
@@ -85,7 +91,13 @@ function openEmployee() {
         </div>
 
         <!-- Departments -->
-        <Section v-if="hasDeptData" title="Departments" class="mt-6">
+        <Section
+          v-if="hasDeptData"
+          title="Departments"
+          class="mt-6"
+          :right="departmentCount ? departmentCount + ' Bereiche' : undefined"
+          description="Wie sich dein Team verteilt: Departments mit aktiven Mitarbeiter:innen."
+        >
           <div class="flex flex-wrap gap-3 md:col-span-2 lg:col-span-3">
             <div
               v-for="(cnt, dept) in data.employees.by_department"
@@ -99,26 +111,40 @@ function openEmployee() {
           </div>
         </Section>
 
-        <div v-else class="card mt-6 text-sm text-brand-muted">
+        <div v-else class="card mt-6 border border-dashed border-white/10 text-sm text-brand-muted">
           Noch keine Department-Daten. Hinterlege <code>department</code> bei den Mitarbeitern.
         </div>
 
         <!-- Schnellzugriff -->
-        <Section title="Schnellzugriff" class="mt-6">
-          <div class="flex flex-wrap items-center gap-3 md:col-span-2 lg:col-span-3">
-            <!-- feste Beispiele -->
-            <RouterLink class="btn" :to="{ name: 'employee', params: { employeeId: 'KIT-0001' } }">KIT-0001</RouterLink>
-            <RouterLink class="btn" :to="{ name: 'employee', params: { employeeId: 'KIT-0002' } }">KIT-0002</RouterLink>
-            <RouterLink class="btn" :to="{ name: 'employee', params: { employeeId: 'KIT-0003' } }">KIT-0003</RouterLink>
-
-
-
-            <!-- Eingabe -->
-              <form class="flex items-center gap-2" @submit.prevent="$router.push({ name: 'employee', params: { employeeId: empSearch } })">
-                <input v-model="empSearch" class="rounded-xl bg-gray-800 text-white placeholder-gray-400 border border-gray-700 px-3 py-2" placeholder="KIT-0001" />
-                <button class="px-3 py-2 rounded-xl bg-amber-500 hover:bg-amber-600 text-black" type="submit">Öffnen</button>
-              </form>
-
+        <Section
+          title="Schnellzugriff"
+          class="mt-6"
+          columns="single"
+          description="Direkt zur Personalakte springen – wähle eine Beispiel-ID oder gib deine eigene ein."
+        >
+          <div class="card flex flex-wrap items-center gap-3 md:gap-4 md:col-span-2 lg:col-span-3">
+            <div class="flex flex-wrap items-center gap-2">
+              <RouterLink
+                v-for="id in quickLinks"
+                :key="id"
+                class="btn-secondary"
+                :to="{ name: 'employee', params: { employeeId: id } }"
+              >
+                {{ id }}
+              </RouterLink>
+            </div>
+            <div class="h-5 w-px bg-white/10 hidden md:block" aria-hidden="true"></div>
+            <form class="flex flex-wrap items-center gap-2" @submit.prevent="openEmployee">
+              <label class="muted text-xs uppercase tracking-[0.2em]" for="emp-id-input">Eigene ID</label>
+              <input
+                id="emp-id-input"
+                v-model="empSearch"
+                class="input"
+                placeholder="z. B. KIT-0007"
+                autocomplete="off"
+              />
+              <button class="btn" type="submit">Öffnen</button>
+            </form>
           </div>
         </Section>
       </div>


### PR DESCRIPTION
## Summary
- restyle the dashboard shell with a branded gradient header and active navigation state
- extend the reusable Section component with description/column options for better layout control
- refresh the overview quick access card, including styled sample links and improved department metadata

## Testing
- npm run build *(fails: existing TypeScript errors in ReminderTable.vue, Dashboard.vue, and related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e188f310e48323b3bd1fefea8565d3